### PR TITLE
feat: refactor payment note with React Hook Form and add character limit

### DIFF
--- a/src/features/payment/payment.tsx
+++ b/src/features/payment/payment.tsx
@@ -130,6 +130,11 @@ export function PaymentScreen() {
   //   setAmount(value);
   // }, []);
 
+  const resetPayment = useCallback(() => {
+    setAmount('0');
+    setDescription('');
+  }, []);
+
   const handleOpenPaymentModal = async () => {
     try {
       const response = await createOrder({
@@ -137,6 +142,8 @@ export function PaymentScreen() {
         display_currency: defaultCurrency?.code ?? 'USD',
         description: description,
       });
+
+      resetPayment();
 
       setPaymentUrl(response.qrcode);
       setOrderId(response.order_id);
@@ -148,10 +155,11 @@ export function PaymentScreen() {
   };
 
   const handleClosePaymentModal = useCallback(() => {
-    setAmount('0');
-    setIsPaymentModalOpen(false);
+    resetPayment();
+
     setPaymentUrl(undefined);
     setOrderId(undefined);
+    setIsPaymentModalOpen(false);
   }, []);
 
   const handleNote = useCallback((note: string) => {
@@ -178,7 +186,7 @@ export function PaymentScreen() {
               dynamicStyles={dynamicStyles}
               onSelectQuickAmount={handleQuickAmount}
             /> */}
-            <ActionSheetPaymentNote onSubmit={handleNote} isEdit={description !== ''} />
+            <ActionSheetPaymentNote onSubmit={handleNote} value={description} isEdit={description !== ''} />
           </View>
         </View>
 

--- a/src/translations/ar.json
+++ b/src/translations/ar.json
@@ -11,6 +11,7 @@
     "description": "وصف",
     "loading": "تحميل",
     "max": "الحد الأقصى",
+    "maxCharacters": "الحد الأقصى {{count}} حرف",
     "merchantId": "معرف التاجر",
     "notFound": "لم يتم العثور عليها",
     "note": "ملحوظة",

--- a/src/translations/bn.json
+++ b/src/translations/bn.json
@@ -11,6 +11,7 @@
     "description": "বর্ণনা",
     "loading": "লোড হচ্ছে",
     "max": "সর্বাধিক",
+    "maxCharacters": "সর্বাধিক {{count}} অক্ষর",
     "merchantId": "বণিক আইডি",
     "notFound": "পাওয়া যায় নি",
     "note": "দ্রষ্টব্য",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -11,6 +11,7 @@
     "description": "Description",
     "loading": "Loading",
     "max": "Maximum",
+    "maxCharacters": "Max {{count}} characters",
     "merchantId": "Merchant ID",
     "notFound": "Not found",
     "note": "Note",

--- a/src/translations/es.json
+++ b/src/translations/es.json
@@ -11,6 +11,7 @@
     "description": "Descripción",
     "loading": "Cargando",
     "max": "Máximo",
+    "maxCharacters": "Máximo {{count}} caracteres",
     "merchantId": "Identificación comercial",
     "notFound": "Extraviado",
     "note": "Nota",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -11,6 +11,7 @@
     "description": "Description",
     "loading": "Chargement",
     "max": "Maximum",
+    "maxCharacters": "Maximum {{count}} caractères",
     "merchantId": "ID marchand",
     "notFound": "Pas trouvé",
     "note": "Note",

--- a/src/translations/hi.json
+++ b/src/translations/hi.json
@@ -11,6 +11,7 @@
     "description": "विवरण",
     "loading": "लोड हो रहा है",
     "max": "अधिकतम",
+    "maxCharacters": "अधिकतम {{count}} वर्ण",
     "merchantId": "व्यापारी आईडी",
     "notFound": "नहीं मिला",
     "note": "टिप्पणी",

--- a/src/translations/id.json
+++ b/src/translations/id.json
@@ -11,6 +11,7 @@
     "description": "Keterangan",
     "loading": "Memuat",
     "max": "Maksimum",
+    "maxCharacters": "Maksimal {{count}} karakter",
     "merchantId": "ID Pedagang",
     "notFound": "Tidak ditemukan",
     "note": "Catatan",

--- a/src/translations/pt.json
+++ b/src/translations/pt.json
@@ -11,6 +11,7 @@
     "description": "Descrição",
     "loading": "Carregando",
     "max": "Máximo",
+    "maxCharacters": "Máximo {{count}} caracteres",
     "merchantId": "ID do comerciante",
     "notFound": "Não encontrado",
     "note": "Observação",

--- a/src/translations/ru.json
+++ b/src/translations/ru.json
@@ -11,6 +11,7 @@
     "description": "Описание",
     "loading": "Загрузка",
     "max": "Максимум",
+    "maxCharacters": "Максимум {{count}} символов",
     "merchantId": "Идентификатор продавца",
     "notFound": "Не найдено",
     "note": "Примечание",

--- a/src/translations/zh.json
+++ b/src/translations/zh.json
@@ -11,6 +11,7 @@
     "description": "描述",
     "loading": "加载中",
     "max": "最大值",
+    "maxCharacters": "最多 {{count}} 个字符",
     "merchantId": "商户ID",
     "notFound": "未找到",
     "note": "备注",


### PR DESCRIPTION
- Refactor ActionSheetPaymentNote to use React Hook Form with Zod validation
- Add 100 character limit to note field with real-time validation
- Display character count subtitle showing current/max characters
- Add "maxCharacters" translation key to all language files (en, id, es, fr, ar, zh, ru, pt, hi, bn)
- Improve button styling and validation feedback
- Truncate long notes in button preview